### PR TITLE
Flip heading indicator and update pixels per degree

### DIFF
--- a/src/main/java/net/torocraft/flighthud/Dimensions.java
+++ b/src/main/java/net/torocraft/flighthud/Dimensions.java
@@ -3,6 +3,8 @@ package net.torocraft.flighthud;
 import net.minecraft.client.MinecraftClient;
 import net.torocraft.flighthud.config.HudConfig;
 
+import java.lang.Math;
+
 public class Dimensions {
 
   public float hScreen;
@@ -31,7 +33,31 @@ public class Dimensions {
       wScreen = wScreen * c.scale;
     }
 
-    degreesPerPixel = hScreen / client.options.getFov().getValue();
+    // The HUD is rendered as a plane in front of the player and not at a
+    // spehere. The degreesPerPixel parameter is therefore a simplification,
+    // which is not exact.
+    //
+    // To use this simplification, a given spot on the screen has to be picked
+    // to be be correct for the approximation.
+    //
+    // Most intuitive would then be to have the horizon line correctly stick to
+    // the world when in the center of the screen. So therefore, calculate the
+    // number of degrees per pixel in the _center_ of the screen
+    //
+    // This simplifies rendering a lot, instead of always calculate the correct
+    // transformation between spherical and cartesian coordinates
+
+
+    // Calculate height of virtual screen at distance of 1 unit
+    // Note that FOV is degrees from top to bottom, we need height from center
+    // to top
+
+    // Also note that "degreesPerPixel" is actually pixels per degree...
+    Integer fov_deg = client.options.getFov().getValue();
+    double hud_height = Math.tan(fov_deg * Math.PI / 180.0 / 2.0);
+    double hud_pixel_height = hud_height / (double)(hScreen/2);
+    degreesPerPixel = 1.0f / (float)(Math.atan(hud_pixel_height) * 180.0 / Math.PI);
+
     xMid = wScreen / 2;
     yMid = hScreen / 2;
 

--- a/src/main/java/net/torocraft/flighthud/Dimensions.java
+++ b/src/main/java/net/torocraft/flighthud/Dimensions.java
@@ -9,7 +9,7 @@ public class Dimensions {
 
   public float hScreen;
   public float wScreen;
-  public float degreesPerPixel;
+  public float pixelsPerDegree;
   public float xMid;
   public float yMid;
 
@@ -34,7 +34,7 @@ public class Dimensions {
     }
 
     // The HUD is rendered as a plane in front of the player and not at a
-    // spehere. The degreesPerPixel parameter is therefore a simplification,
+    // spehere. The pixelsPerDegree parameter is therefore a simplification,
     // which is not exact.
     //
     // To use this simplification, a given spot on the screen has to be picked
@@ -52,11 +52,10 @@ public class Dimensions {
     // Note that FOV is degrees from top to bottom, we need height from center
     // to top
 
-    // Also note that "degreesPerPixel" is actually pixels per degree...
     Integer fov_deg = client.options.getFov().getValue();
     double hud_height = Math.tan(fov_deg * Math.PI / 180.0 / 2.0);
     double hud_pixel_height = hud_height / (double)(hScreen/2);
-    degreesPerPixel = 1.0f / (float)(Math.atan(hud_pixel_height) * 180.0 / Math.PI);
+    pixelsPerDegree = 1.0f / (float)(Math.atan(hud_pixel_height) * 180.0 / Math.PI);
 
     xMid = wScreen / 2;
     yMid = hScreen / 2;

--- a/src/main/java/net/torocraft/flighthud/components/FlightPathIndicator.java
+++ b/src/main/java/net/torocraft/flighthud/components/FlightPathIndicator.java
@@ -32,7 +32,8 @@ public class FlightPathIndicator extends HudComponent {
     float x = dim.xMid;
 
     y += i(deltaPitch * dim.degreesPerPixel);
-    x += i(deltaHeading * dim.degreesPerPixel);
+    // Subtract X, so the flight path indicator moves into the turn when turning
+    x -= i(deltaHeading * dim.degreesPerPixel);
 
     if (y < dim.tFrame || y > dim.bFrame || x < dim.lFrame || x > dim.rFrame) {
       return;

--- a/src/main/java/net/torocraft/flighthud/components/FlightPathIndicator.java
+++ b/src/main/java/net/torocraft/flighthud/components/FlightPathIndicator.java
@@ -31,9 +31,9 @@ public class FlightPathIndicator extends HudComponent {
     float y = dim.yMid;
     float x = dim.xMid;
 
-    y += i(deltaPitch * dim.degreesPerPixel);
+    y += i(deltaPitch * dim.pixelsPerDegree);
     // Subtract X, so the flight path indicator moves into the turn when turning
-    x -= i(deltaHeading * dim.degreesPerPixel);
+    x -= i(deltaHeading * dim.pixelsPerDegree);
 
     if (y < dim.tFrame || y > dim.bFrame || x < dim.lFrame || x > dim.rFrame) {
       return;

--- a/src/main/java/net/torocraft/flighthud/components/HeadingIndicator.java
+++ b/src/main/java/net/torocraft/flighthud/components/HeadingIndicator.java
@@ -23,7 +23,7 @@ public class HeadingIndicator extends HudComponent {
     float top = dim.tFrame - 10;
 
     float yText = top - 7;
-    float northOffset = computer.heading * dim.degreesPerPixel;
+    float northOffset = computer.heading * dim.pixelsPerDegree;
     float xNorth = dim.xMid - northOffset;
 
     if (CONFIG.heading_showReadout) {
@@ -34,7 +34,7 @@ public class HeadingIndicator extends HudComponent {
     if (CONFIG.heading_showScale) {
       drawPointer(m, dim.xMid, top + 10, 0);
       for (int i = -540; i < 540; i = i + 5) {
-        float x = (i * dim.degreesPerPixel) + xNorth;
+        float x = (i * dim.pixelsPerDegree) + xNorth;
         if (x < left || x > right)
           continue;
 

--- a/src/main/java/net/torocraft/flighthud/components/PitchIndicator.java
+++ b/src/main/java/net/torocraft/flighthud/components/PitchIndicator.java
@@ -21,7 +21,7 @@ public class PitchIndicator extends HudComponent {
   public void render(MatrixStack m, float partial, MinecraftClient mc) {
     pitchData.update(dim);
 
-    float horizonOffset = computer.pitch * dim.degreesPerPixel;
+    float horizonOffset = computer.pitch * dim.pixelsPerDegree;
     float yHorizon = dim.yMid + horizonOffset;
 
     float a = dim.yMid;
@@ -63,7 +63,7 @@ public class PitchIndicator extends HudComponent {
     }
 
     for (int i = degreesPerBar; i <= 90; i = i + degreesPerBar) {
-      float offset = dim.degreesPerPixel * i;
+      float offset = dim.pixelsPerDegree * i;
       drawDegreeBar(mc, m, -i, yHorizon + offset);
       drawDegreeBar(mc, m, i, yHorizon - offset);
     }
@@ -75,7 +75,7 @@ public class PitchIndicator extends HudComponent {
       return;
     }
 
-    float y = (-degrees * dim.degreesPerPixel) + yHorizon;
+    float y = (-degrees * dim.pixelsPerDegree) + yHorizon;
 
     if (y < dim.tFrame || y > dim.bFrame) {
       return;


### PR DESCRIPTION
Just did a test with the updated rotation calculation, and it looked almost correct.

I noticed two things though:

## Heading indicator

When turning, the heading indicator moved out of the turn. I would expect the heading indicator when turning is no exact science, but it felt way better when it moved into the turn, since it shows where to end up. So this patch flips that indicator

## pixels per degree

At small pitch angles, the horizon line is correct, but when pitching up/down, it looks like the horizon line doesn't stick to the environment.

That is because the assumption that the HUD is projected on a spherical screen, which is not correct. This is due to the approximation that each pixel has the same angular size (as in pixels per degree or degrees per pixel is constant)

The correct solution would be to actually do the spherical to screen coordinate translation everywhere when rendering. However, that's a bigger patch.

A simpler but pretty good approximation is that we focus on the center of the screen, and calculate the angular size of a pixel there. That would result in near correct behavior in the center, and good enough closer to the edge. And it significantly improves the "stickiness" of the horizon line to the environment.

This patches that calculation in the Dimensions class.

Also, the variable defining translation of degrees to pixels was incorrectly named. `degreesPerPixel` contained the number of pixels per degree. So changed the name to `pixelsPerDegree` to better describe the content.